### PR TITLE
FIX, modules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,42 @@
+# See http://help.github.com/ignore-files/ for more about ignoring files.
+
+# Compiled output
+/dist
+/tmp
+/out-tsc
+/bazel-out
+
+# Node
+/node_modules
+npm-debug.log
+yarn-error.log
+
+# IDEs and editors
+.idea/
+.project
+.classpath
+.c9/
+*.launch
+.settings/
+*.sublime-workspace
+
+# Visual Studio Code
+.vscode/*
+!.vscode/settings.json
+!.vscode/tasks.json
+!.vscode/launch.json
+!.vscode/extensions.json
+.history/*
+
+# Miscellaneous
+/.angular/cache
+.sass-cache/
+/connect.lock
+/coverage
+/libpeerconnection.log
+testem.log
+/typings
+
+# System files
+.DS_Store
+Thumbs.db

--- a/angular.json
+++ b/angular.json
@@ -105,5 +105,8 @@
         }
       }
     }
+  },
+  "cli": {
+    "analytics": false
   }
 }

--- a/src/app/modules/material-module.module.ts
+++ b/src/app/modules/material-module.module.ts
@@ -14,22 +14,6 @@ import { MatListModule } from '@angular/material/list';
 
 
 @NgModule({
-  declarations: [
-    MatTableModule,
-    MatButtonModule,
-    MatIconModule,
-    MatDialogModule,
-    MatFormFieldModule,
-    MatInputModule,
-    MatToolbarModule,
-    MatSidenavModule,
-    MatListModule,
-  ],
-  imports: [
-    CommonModule,
-    ComponentsModule,
-    
-  ],
   exports: [
     MatTableModule,
     MatButtonModule,


### PR DESCRIPTION
Cree el .gitignore porque me subia si no todos los node_modules y demas... recomiendo que lo hagas, tambien arregle el material module, ese modulo solo sirve para importar en otros modulos y cargar todos los componentes de material, como esa es su funcion no es necesario que tenga array de declarations ni imports, de hecho eso hacia que falle la app